### PR TITLE
Add a #:do fragment to ppict-do

### DIFF
--- a/unstable-doc/scribblings/gui/pslide.scrbl
+++ b/unstable-doc/scribblings/gui/pslide.scrbl
@@ -33,6 +33,7 @@ compact notation for sequences of those two operations.
                                   (code:line #:set pict-expr)
                                   (code:line #:next)
                                   (code:line #:alt (ppict-do-fragment ...))
+                                  (code:line #:do [def-or-expr ...])
                                   (code:line elem-expr)])
               #:contracts ([base-expr pict?]
                            [placer-expr placer?]
@@ -53,6 +54,10 @@ picts yet to come). A @racket[#:alt] fragment saves the current pict
 state, executes the sub-sequence that follows, saves the result (as if
 the sub-sequence ended with @racket[#:next]), then restores the saved
 pict state before continuing.
+
+A @racket[#:do] fragment embeds definitions and expressions which are
+run when the pict state is computed. The definitions are bound in the
+rest of the fragments in the pict.
 
 The @racket[elem-expr]s are interpreted by the current placer. A
 numeric @racket[elem-expr] usually represents a spacing change, but
@@ -120,6 +125,17 @@ circles-down-1
                          #:alt [(rectangle 20 20)]
                          (text "and more!"))])
   (append intermediates (list final)))
+]
+
+The following demonstrates the use of the @racket[#:do] fragment:
+
+@examples[#:eval the-eval
+(ppict-do base
+          #:do [(define c (circle 20))
+                (define r (rectangle 20 20))
+                (set! c (circle 25))]
+          #:go (coord 0.5 0.5)
+          (hc-append c r))
 ]
 
 More examples of @racket[ppict-do] are scattered throughout this

--- a/unstable-lib/gui/private/ppict-syntax.rkt
+++ b/unstable-lib/gui/private/ppict-syntax.rkt
@@ -10,7 +10,7 @@
 (define-syntax-class (fragment-sequence who xp-var rpss-var)
   #:commit
   #:local-conventions ([p (elem who)]
-                       #|[b (bind-fragment who)]|#
+                       [d (do-fragment who)]
                        [g (go-fragment who)]
                        [s (set-fragment who)]
                        [a (alt-fragment who)]
@@ -38,15 +38,9 @@
                                                   (make-rename-transformer #'#,xp-var)])
                              (ppict-go #,xp-var g.placer))])
                fs.code))
-  #|
-  (pattern (b . fs)
+  (pattern (d . fs)
            #:with code
-           #`(let*-values ([(b.var ...)
-                            (syntax-parameterize ([ppict-do-state
-                                                   (make-rename-transformer #'#,xp-var)])
-                              b.rhs)])
-               fs.code))
-  |#
+           #`(let () d.body ...  fs.code))
   (pattern (s . fs)
            #:with code
            #`(let*-values ([(#,xp-var picts)
@@ -72,12 +66,9 @@
            #:declare pl (expr/c #'placer? #:name "placer argument of #:go fragment")
            #:with placer #'pl.c))
 
-#|
-(define-splicing-syntax-class (bind-fragment who)
-  #:description "#:bind fragment"
-  (pattern (~seq #:bind vs:var/vars rhs:expr)
-           #:with (var ...) #'(vs.var ...)))
-|#
+(define-splicing-syntax-class (do-fragment who)
+  #:description "#:do fragment"
+  (pattern (~seq #:do [body:expr ...])))
 
 (define-splicing-syntax-class (set-fragment who)
   #:description "#:set fragment"


### PR DESCRIPTION
Add a `#:do` fragment to `ppict-do` for doing `let`-like bindings inside ppicts. Replaces the commented out `#:bind` fragments.
