### PR TITLE
doc: fix broken link to automata package

### DIFF
--- a/unstable-doc/scribblings/automata.scrbl
+++ b/unstable-doc/scribblings/automata.scrbl
@@ -3,4 +3,4 @@
 @title{Automata}
 @defmodule[unstable/automata]
 
-@deprecated[@racketmodname[automata]]{}
+@deprecated[@other-doc['(lib "automata/scribblings/automata.scrbl")]]{}


### PR DESCRIPTION
there is no `automata/main.rkt` module, so link to the package documentation